### PR TITLE
Added predction for folder of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ python main.py eval with dataset.root_dir=/path/to/save/processd/data resume_dir
 ```
 
 ### Prediction
-Run the following command to predict on a single image:
+Run the following command to predict on a single image or a folder of images:
 ```bash
 python predict.py with resume_dir=pretrained.pt image_path=/path/to/image
 ```

--- a/predict.py
+++ b/predict.py
@@ -57,8 +57,9 @@ def predict(_run, _log):
 
     h, w = 192, 256
     
-    for f in os.listdir('./predict'):
-        os.remove('./predict/'+f)
+    if os.path.isdir('./predict'):
+        for f in os.listdir('./predict'):
+            os.remove('./predict/'+f)
 
     with torch.no_grad():
         if os.path.isdir(cfg.image_path):


### PR DESCRIPTION
The prediction method now works for both, single image and a folder of images. It can be quite a tiresome process to run the prediction for many images to get the general idea of how the network is performing on some custom dataset. Therefore, this pull request.

I have changed the following files:
- `README.md`

- `predict.py`

In `Readme.md` I have just changed the line that says prediction runs for a single image.

In `predict.py` I have added a few lines to handle the prediction on a folder of images. The code now does the following things along with the things that it did earlier:
- checks if `./predict` is already available. If not, it makes `./predict` folder. If it is available, deletes all the files (probably from previous runs) that are already there in the folder.

-  Saves the `pred_seg`, `blend_pred`, `mask`, `depth` images as the `input_file_name_<type>.png` in `./predict` folder where `<type>` is one of `seg`, `blend`, `mask`, `depth`.

Also, I want to thank you for such great work. I am sorry for any mistakes that I might have made in this PR because it is my first one ever.